### PR TITLE
add second User config

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ over
 
 The main configuration consists of deciding which icons to use for which applications.
 
-The config file is located at `${XDG_CONFIG_HOME}/sworkstyle/config.toml`. It will be generated if missing. Read the generated file. The syntax is in TOML and should be pretty self-explanatory. A secondardy config file called user-config.toml will be added at the end of the main config file if it exists.
+The config file is located at `${XDG_CONFIG_HOME}/sworkstyle/config.toml`. It will be generated if missing. Read the generated file. The syntax is in TOML and should be pretty self-explanatory. A secondary config file called user-config.toml will be added at the end of the main config file if it exists.
 
 When an app isn't recogised in the config, `sworkstyle` will log the application name as a warning.
 Simply add that string to your config file, with an icon of your choice.

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ over
 
 The main configuration consists of deciding which icons to use for which applications.
 
-The config file is located at `${XDG_CONFIG_HOME}/sworkstyle/config.toml`. It will be generated if missing. Read the generated file. The syntax is in TOML and should be pretty self-explanatory.
+The config file is located at `${XDG_CONFIG_HOME}/sworkstyle/config.toml`. It will be generated if missing. Read the generated file. The syntax is in TOML and should be pretty self-explanatory. A secondardy config file called user-config.toml will be added at the end of the main config file if it exists.
 
 When an app isn't recogised in the config, `sworkstyle` will log the application name as a warning.
 Simply add that string to your config file, with an icon of your choice.

--- a/src/config.rs
+++ b/src/config.rs
@@ -84,6 +84,12 @@ fn get_user_config_content() -> anyhow::Result<String> {
     } else {
         content = read_to_string(sworkstyle_config_path)?;
     }
+//Add a second config file if it exists
+let sworkstyle_config_path_user = sworkstyle_config_dir.join("user-config.toml");
+if sworkstyle_config_path_user.exists() {
+let user_file = read_to_string(sworkstyle_config_path_user);
+content.extend(user_file);
+}
 
     Ok(content)
 }


### PR DESCRIPTION
Add a second config file called: user-config.toml.
This allows linux distribution to prepackage a config file and users to add there extras to another file for easier updates of dotfiles