### PR TITLE
Add cmdline arg for specifying config location

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,6 @@ See [aur](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=sworkstyle) for
 ## Roadmap
 
 - Allow multiple instances of a program to be displayed with only one icon `unique = true`
-- Cmdline arg for specifying config location `-c {path_to_config}`
 
 ## Known Issues
 

--- a/src/args.rs
+++ b/src/args.rs
@@ -4,11 +4,13 @@ use log::LevelFilter;
 
 pub struct Args {
     pub log_level: LevelFilter,
+    pub config_path: Option<String>,
 }
 
 impl Args {
     pub fn from_cli() -> Args {
         let mut log_level: LevelFilter = LevelFilter::Warn;
+        let mut config_path = None;
 
         let mut args = env::args().skip(1);
         while let Some(arg) = args.next() {
@@ -27,7 +29,11 @@ FLAGS
         Display a description of this program.
 
     --log-level
-        Either \"error\", \"warn\", \"info\", \"debug\". Uses \"warn\" by default"
+        Either \"error\", \"warn\", \"info\", \"debug\". Uses \"warn\" by default
+        
+    -c, --config
+        Specifies the config file to use.
+        "
                     );
                     process::exit(0);
                 }
@@ -48,6 +54,14 @@ FLAGS
                         process::exit(1);
                     }
                 }
+                "-c" | "--config" => {
+                    if let Some(path) = args.next() {
+                        config_path = Some(String::from(path));
+                    } else {
+                        eprintln!("No path given");
+                        process::exit(1);
+                    }
+                }
                 _ => {
                     eprintln!("Did not recognize \"{}\" as an option", arg);
                     process::exit(1);
@@ -55,6 +69,9 @@ FLAGS
             }
         }
 
-        return Args { log_level };
+        return Args {
+            log_level,
+            config_path,
+        };
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,7 +149,7 @@ async fn main() -> Fallible<()> {
 
     check_already_running();
 
-    let config = Config::new();
+    let config = Config::new(args.config_path);
 
     subscribe_to_window_events(config).await?;
 


### PR DESCRIPTION
Add ability to specify config location as per the README.md. The program should function the same if no path or a faulty path was given.