### PR TITLE
feat: config option to force left to right format

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,10 +107,19 @@ You can use {title} to do a generic matching
 
 You can use {app_name} to do an exact match
 
+If a workspace name is reversed, you can force left to right formatting
+
+```toml
+'force_ltr' = true
+```
+The default value of `force_ltr` is `false`
+
 ### Default Config
 
 ```toml
 fallback = ''
+
+force_ltr = false
 
 [matching]
 'discord' = ''

--- a/src/config.rs
+++ b/src/config.rs
@@ -52,6 +52,7 @@ enum Match {
 struct MatchConfig {
     matching: Vec<Match>,
     fallback: Option<String>,
+    force_ltr: Option<bool>,
 }
 
 pub struct Config {
@@ -152,8 +153,15 @@ fn parse_content_to_icon_map(content: &String) -> anyhow::Result<MatchConfig> {
                 }
                 None => None,
             };
+            let force_ltr: Option<bool> = match root.get("force_ltr") {
+                Some(value) => {
+                    let f = value.as_bool().with_context(|| "force_ltr is not a boolean")?;
+                    Some(f)
+                }
+                None => Some(false),
+            };
 
-            Ok(MatchConfig { matching, fallback })
+            Ok(MatchConfig { matching, fallback, force_ltr })
         }
         _ => bail!("No root table found"),
     }
@@ -260,5 +268,9 @@ impl Config {
                 String::from("")
             }
         }
+    }
+
+    pub fn should_force_ltr(&mut self) -> bool {
+		self.match_config.force_ltr.unwrap_or_default()
     }
 }

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -24,6 +24,8 @@
 
 fallback = ''
 
+force_ltr = false
+
 [matching]
 'discord' = ''
 'balena-etcher' = ''

--- a/src/main.rs
+++ b/src/main.rs
@@ -53,9 +53,16 @@ async fn update_workspace_name(
 
     let mut icons = icons.join(" ");
     if icons.len() > 0 {
-        icons.push_str(" ")
-    }
+        icons.push_str(" ");
 
+        if config.should_force_ltr() {
+            let format_ltr = "\u{202D}";
+            let format_pop = "\u{202C}";
+            icons.insert_str(0, format_ltr);
+            icons.push_str(format_pop);
+        }
+    }
+	
     let new_name = if icons.len() > 0 {
         format!("{}: {}", index, icons)
     } else if let Some(num) = workspace.num {


### PR DESCRIPTION
This PR adds a "force_ltr" option to the config file, allowing users to work around fonts that overwrite characters in RTL languages (see issue #22 for more details). I debated doing this as a command line arg, but because the option should probably persist across instances and is only relevant to specific characters in the config, I decided a new config file option was a better choice.

Apologies if this code isn't up to any standards, I tried to maintain the styling present but this is also the first bit of rust I've ever written. 