### PR TITLE
Add option to remove duplicate icons

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,8 @@ An executable similar to [workstyle](https://github.com/pierrechevalier83/workst
 
 - Fallback Icon
 
+- Unique option
+
 Your workspace shall never contain an empty icon again!
 
 **An example of what it does (using waybar which also hides the workspace index):**
@@ -78,6 +80,8 @@ Note that the crate [find_unicode](https://github.com/pierrechevalier83/find_uni
 
 For a reference to the regex syntax see the [regex](https://docs.rs/regex/1.5.4/regex/#syntax) crate
 
+The configuration contains an option called `unique` which defaults to `false`. When `unique` is set to `true`, `sworkstyle` will only show the unique icons on each workspace. In other words, icons within each workspace will never repeat. For example, if you have three identical applications open within the same workspace, only 1 icon will be present.
+
 ### Matching
 
 #### Standard
@@ -111,6 +115,7 @@ You can use {app_name} to do an exact match
 
 ```toml
 fallback = ''
+unique = false
 
 [matching]
 'discord' = ''
@@ -153,7 +158,7 @@ See [aur](https://aur.archlinux.org/cgit/aur.git/tree/PKGBUILD?h=sworkstyle) for
 
 ## Roadmap
 
-- Allow multiple instances of a program to be displayed with only one icon `unique = true`
+- All current items on the roadmap have been completed.
 
 ## Known Issues
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -49,13 +49,14 @@ enum Match {
 }
 
 #[derive(Clone, Debug)]
-struct MatchConfig {
+pub struct MatchConfig {
     matching: Vec<Match>,
     fallback: Option<String>,
+    pub unique: Option<bool>,
 }
 
 pub struct Config {
-    match_config: MatchConfig,
+    pub match_config: MatchConfig,
 }
 
 /// Fetch user config content and create a config file if does not exist
@@ -153,7 +154,15 @@ fn parse_content_to_icon_map(content: &String) -> anyhow::Result<MatchConfig> {
                 None => None,
             };
 
-            Ok(MatchConfig { matching, fallback })
+            let unique: Option<bool> = match root.get("unique") {
+                Some(value) => {
+                    let f = value.as_bool().with_context(|| "Unique is not a bool")?;
+                    Some(f)
+                }
+                None => None,
+            };
+
+            Ok(MatchConfig { matching, fallback, unique })
         }
         _ => bail!("No root table found"),
     }

--- a/src/default_config.toml
+++ b/src/default_config.toml
@@ -23,6 +23,7 @@
 # You can use {app_name} to do an exact match
 
 fallback = ''
+unique = false
 
 [matching]
 'discord' = ''

--- a/src/main.rs
+++ b/src/main.rs
@@ -36,10 +36,16 @@ async fn update_workspace_name(
     let mut windows = vec![];
     get_windows(workspace, &mut windows);
 
-    let icons: Vec<String> = windows
+    let mut icons: Vec<String> = windows
         .iter()
         .map(|node| config.fetch_icon(&node).to_string())
         .collect();
+
+    // remove duplicate icons
+    if config.match_config.unique == Some(true) {
+        icons.sort();
+        icons.dedup();
+    }
 
     let name = match &workspace.name {
         Some(name) => name,


### PR DESCRIPTION
The code is a little messy but it gets the job done. I didn't know any Rust prior to this PR so I'm sure some things can be improved.

Essentially, this PR adds a new `Config` field called `unique` and makes it public all the way up the chain of structs, so that `main.rs` can read the value of `config.match_config.unique` and determine whether to remove duplicate icons.

In order to deduplicate the vector of icons, it first had to be `sort`ed, so now the icons are not in any meaningful order anymore (when `unique` is `true`). In other words, applications open on the left or right side of the screen may have their icon on the wrong side of the workspace's name.

I mostly copied your code for the configuration file checks and it seems to work.