### PR TITLE
add separator support

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -59,6 +59,7 @@ pub enum Match {
 pub struct Config {
     pub matchings: Vec<Match>,
     pub fallback: Option<String>,
+    pub separator: Option<String>,
 }
 
 impl Config {

--- a/src/config/parse_content_to_config.rs
+++ b/src/config/parse_content_to_config.rs
@@ -89,9 +89,20 @@ pub fn parse_content_to_config(content: &String) -> Result<Config, ConfigError> 
                 None => None,
             };
 
+            let separator: Option<String> = match root.get("separator") {
+                Some(value) => {
+                    let f = value
+                        .as_str()
+                        .ok_or(ConfigError::new("Separator is not a string"))?;
+                    Some(f.to_string())
+                }
+                None => None,
+            };
+
             Ok(Config {
                 matchings: matching,
                 fallback,
+                separator,
             })
         }
         _ => Err(ConfigError::new("No root table found")),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -186,7 +186,12 @@ impl Sworkstyle {
             icons.dedup();
         }
 
-        let mut icons = icons.join(" ");
+        let delim = self.config.separator
+            .as_deref()
+            .unwrap_or(" ");
+
+        let mut icons = icons.join(delim);
+
         if icons.len() > 0 {
             icons.push_str(" ")
         }


### PR DESCRIPTION
Adds a root field to the config named `separator`, to which one assigns a string.

This string is then printed in between each of the icons.
It defaults to `" "`, such that this code changes [nothing](https://github.com/Lyr-7D1h/swayest_workstyle/blob/master/src/lib.rs#L189) if no separator is given.

Allows for:
- Greater margin
- A separator like '/' or some nerd font icon or whatever.

Without having to make tedious changes to the config.