### PR TITLE
filter out empty icons to prevent separator

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,7 @@ impl Sworkstyle {
                         .to_string()
                 }
             })
+            .filter(|icon| !icon.is_empty())
             // Overwrite right to left characters: https://www.unicode.org/versions/Unicode12.0.0/UnicodeStandard-12.0.pdf#G26.16327
             .map(|icon| format!("\u{202D}{icon}\u{202C}"))
             .collect();


### PR DESCRIPTION
Allows preventing a window from producing an icon by setting the icon as an empty string.

Unlike having an empty separator and including the separator into every icon, this solution does not produce an unwanted outside separator. Furthermore, default configurations don't need to be overwritten.

This is not entirely backwards-compatible, as any configuration previously intentionally using the current behaviour on empty icons would observe changes. But I am unsure what would be the use-case for such a configuration.
If necessary, this behaviour could still be made opt-in using a flag in the configuration.