### PR TITLE
On error in main, exit with return code 1

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -150,6 +150,7 @@ async fn main() {
         .run()
         .await
     {
-        error!("{e}")
+        error!("{e}");
+        process::exit(1)
     }
 }


### PR DESCRIPTION
Previously, on error from main, it would log the error but return exit code 0.

I start sworkstyle via a user systemd service with `Restart=on-failure`, and this was not considered a failure.