### PR TITLE
fix: Fix spotify icon adding lower case

### DIFF
--- a/default_config.toml
+++ b/default_config.toml
@@ -55,6 +55,7 @@ separator = ' '
 'jetbrains-studio' = ''
 "transmission-remote-gtk" = ""
 'Spotify' = ''
+'spotify' = ''
 'GitHub Desktop' = ''
 '/(?i)^Github.*Firefox/' = ''
 'firefox' = ''


### PR DESCRIPTION
It sems that in Arch Linux with spotify-launcher, the appid is spotify instead Spotify.